### PR TITLE
[refactor] 이동로직에 queue 사용 삭제 및 변수, 함수명 수정

### DIFF
--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -11,8 +11,8 @@ public enum GamePhase
 public class BoardManager : Singleton<BoardManager>
 {
     [SerializeField] private GamePhase _currentPhase;
-    [SerializeField] private int _maxGameRound; //테스트를 위해 인스펙터 노출 추후 수정 예정
-    [SerializeField] private int _currentGameRound;
+    [SerializeField] private int _maxRound; //테스트를 위해 인스펙터 노출 추후 수정 예정
+    [SerializeField] private int _currentRound;
     [SerializeField] private List<Player> _playerList;
     [SerializeField] private Board _board;
     [SerializeField] private Player _currentPlayer;
@@ -28,8 +28,8 @@ public class BoardManager : Singleton<BoardManager>
         base.Awake();
 
         _currentPhase = GamePhase.GameReady;
-        _maxGameRound = 2;
-        _currentGameRound = 0;
+        _maxRound = 2;
+        _currentRound = 0;
         _currentPlayerIndex = 0;
         //players = new List<Player>();
         //initialize board
@@ -103,10 +103,10 @@ public class BoardManager : Singleton<BoardManager>
                 if (_currentPlayerIndex == _playerList.Count)
                 {
                     _currentPlayerIndex = 0;
-                    _currentGameRound++;
+                    _currentRound++;
                 }
 
-                if (_currentGameRound == _maxGameRound)
+                if (_currentRound == _maxRound)
                 {
                     _currentPhase = GamePhase.GameEnd;
                 }

--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -10,13 +11,13 @@ public enum GamePhase
 public class BoardManager : Singleton<BoardManager>
 {
     [SerializeField] private GamePhase _currentPhase;
-    [SerializeField] private int _maxGameTurn; //테스트를 위해 인스펙터 노출 추후 수정 예정
-    [SerializeField] private int _currentGameTurn;
+    [SerializeField] private int _maxGameRound; //테스트를 위해 인스펙터 노출 추후 수정 예정
+    [SerializeField] private int _currentGameRound;
     [SerializeField] private List<Player> _playerList;
     [SerializeField] private Board _board;
     [SerializeField] private Player _currentPlayer;
 
-    private int _currentPlayerIndex; // 현재 움직이고 있는 플레이어의 인덱스스
+    private int _currentPlayerIndex; // 현재 움직이고 있는 플레이어의 인덱스
     private int _setTurnOrderIndex;
     private List<(int, Player)> _playerDiceNumberList = new List<(int, Player)>();
 
@@ -25,10 +26,10 @@ public class BoardManager : Singleton<BoardManager>
     public override void Awake()
     {
         base.Awake();
-        
+
         _currentPhase = GamePhase.GameReady;
-        _maxGameTurn = 2;
-        _currentGameTurn = 0;
+        _maxGameRound = 2;
+        _currentGameRound = 0;
         _currentPlayerIndex = 0;
         //players = new List<Player>();
         //initialize board
@@ -36,7 +37,7 @@ public class BoardManager : Singleton<BoardManager>
         _setTurnOrderIndex = 0;
 
         //player 순서 정하는 list 초기화
-        for (int i=0; i<_playerList.Count; ++i)
+        for (int i = 0; i < _playerList.Count; ++i)
         {
             (int, Player) playerDiceNumber;
 
@@ -48,7 +49,7 @@ public class BoardManager : Singleton<BoardManager>
 
     private void Start()
     {
-        StartGame();
+        StartBoardGame();
     }
 
     private void Update()
@@ -67,11 +68,11 @@ public class BoardManager : Singleton<BoardManager>
 
                 if (IsAllPlayerRolledDiceForOrder())
                 {
-                    SetPlayerTurnOrder();
+                    SetTurnOrder();
                     _currentPhase = GamePhase.GamePlay;
                 }
             }
-            
+
             //Player 1
             if (Input.GetKeyDown(KeyCode.S))
             {
@@ -84,29 +85,28 @@ public class BoardManager : Singleton<BoardManager>
 
                 if (IsAllPlayerRolledDiceForOrder())
                 {
-                    SetPlayerTurnOrder();
+                    SetTurnOrder();
                     _currentPhase = GamePhase.GamePlay;
                 }
             }
         }
-        
+
         if (_currentPhase == GamePhase.GamePlay)
         {
             if (Input.GetKeyDown(KeyCode.Space))
             {
-                //MovePlayerByTileQueue();
                 _currentPlayer = _playerList[_currentPlayerIndex];
                 _currentPlayer._dice.gameObject.SetActive(false);
-                ProcessPlayerTurn(_currentPlayer);
+                ProcessTurn(_currentPlayer);
                 _currentPlayerIndex++;
 
                 if (_currentPlayerIndex == _playerList.Count)
                 {
                     _currentPlayerIndex = 0;
-                    _currentGameTurn++;
+                    _currentGameRound++;
                 }
 
-                if (_currentGameTurn == _maxGameTurn)
+                if (_currentGameRound == _maxGameRound)
                 {
                     _currentPhase = GamePhase.GameEnd;
                 }
@@ -114,12 +114,12 @@ public class BoardManager : Singleton<BoardManager>
         }
     }
 
-    private void StartGame()
+    private void StartBoardGame()
     {
         _currentPhase = GamePhase.GameReady;
     }
 
-    private void SetPlayerTurnOrder()
+    private void SetTurnOrder()
     {
         _playerDiceNumberList.Sort((a, b) => b.Item1.CompareTo(a.Item1));
 
@@ -143,18 +143,29 @@ public class BoardManager : Singleton<BoardManager>
         _setTurnOrderIndex++;
     }
 
-    private void ProcessPlayerTurn(Player currentPlayer)
+    private void ProcessTurn(Player currentPlayer)
     {
-        //주사위 던지기
-        int playersDiceNum = _currentPlayer.RollDice();
+        int playersDiceNum = _currentPlayer.RollDice(); //주사위 던지기
+        StartCoroutine(SendTileCo(currentPlayer, playersDiceNum)); //움직여
+    }
+    private IEnumerator SendTileCo(Player player, int diceValue)
+    {
+        int tileIndex = player.currentTile.tileIndex;
 
-        //주사위 수 만큼 타일 이동 명령
-        int index = _currentPlayer.currentTile.tileIndex + 1;
-        for (int i = 0; i < playersDiceNum; i++)
+        for (int i = 0; i < diceValue; i++) //한 타일씩 -> 나중에 갈림길 고려
         {
-            _currentPlayer.MoveTo(_board.tiles[index]);
-            index++;
-            (index) %= _board.tiles.Length;
+            int nextIndex = (tileIndex + 1) % _board.tiles.Length;
+            Tile nextTile = _board.tiles[nextIndex];
+
+            player.MoveTo(nextTile);
+            tileIndex = nextIndex;
+
+            while (player.IsMoving)
+            {
+                yield return null;
+            }
+
+            yield return new WaitForSeconds(0.1f);
         }
     }
 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -11,25 +11,10 @@ public class Player : MonoBehaviour
     [SerializeField] public Dice _dice;
     [SerializeField] private List<GameObject> _diceNumberObjects = new List<GameObject>(); // Comment: 아래 변수도 불필요
 
-    private Queue<Tile> _moveQueue = new Queue<Tile>();
     private bool _isMoving = false;
-    [SerializeField] float moveSpeed = 5f;
+    [SerializeField] private float moveSpeed = 5f;
 
     public bool IsMoving { get { return _isMoving; } }
-
-    private void Awake()
-    {
-        _moveQueue = new Queue<Tile>();
-    }
-
-    private void Update()
-    {
-        if (_moveQueue.Count > 0 && !_isMoving) //움직이고 있지 않고 큐가 차면
-        {
-            _isMoving = true;
-            StartCoroutine(MoveTileQueue());
-        }
-    }
 
     public int RollDice()
     {
@@ -37,65 +22,35 @@ public class Player : MonoBehaviour
         return _dice.Roll();
     }
 
-    public void GetMoveQueue(Queue<Tile> tileQueue)
-    {
-        _moveQueue.Clear();
-        _moveQueue = tileQueue;//타일 큐를 받아와서
-    }
-
-    private IEnumerator MoveTileQueue()
-    {
-        //int _diceValueUI = _dice.DiceValue-1;
-        //_diceNumberObjects[_diceValueUI].SetActive(true);
-        for (int i = 0; i < _moveQueue.Count; i++)
-        {
-            Tile nextTile = _moveQueue.Dequeue();
-
-/*          int current = nextTile.tileIndex - i;
-            int next = nextTile.tileIndex - i - 1;
-            if (current < _diceNumberObjects.Count && next >= 0)
-            {
-                if (_diceNumberObjects[current] != null)
-                    _diceNumberObjects[current].SetActive(false);
-                if (_diceNumberObjects[next] != null)
-                    _diceNumberObjects[next].SetActive(true);
-            }
-*/
-            Vector3 startPos = transform.position;
-            Vector3 endPos = nextTile.transform.position;
-            float distance = Vector3.Distance(startPos, endPos);
-            float duration = distance / moveSpeed;
-            float elapsed = 0f;
-
-            while (elapsed < duration)
-            {
-                transform.position = Vector3.Lerp(startPos, endPos, elapsed / duration);
-                elapsed += Time.deltaTime;
-                yield return null;
-            }
-
-            transform.position = endPos; // 최종 위치 보정
-            currentTile = nextTile;
-            yield return new WaitForSeconds(0.1f);
-
-        }
-        _isMoving = false;
-        
-    }
-
     public void MoveTo(Tile nextTile)
     {
-        if (_moveQueue != null)
+        if (!_isMoving)
         {
-            _moveQueue.Enqueue(nextTile);
+            StartCoroutine(MoveToSequenceCo(nextTile));
         }
     }
-        
-    // comment: 아래 로직은 필히 없어져야 함.
-    private IEnumerator MoveCoroutine(Tile nextTile)
+
+    private IEnumerator MoveToSequenceCo(Tile nextTile)
     {
-        transform.position = nextTile.transform.position;
+        _isMoving = true;
+        Vector3 startPos = transform.position;
+        Vector3 endPos = nextTile.transform.position;
+        float distance = Vector3.Distance(startPos, endPos);
+        float duration = distance / moveSpeed;
+        float elapsed = 0f;
+
+        while (elapsed < duration)
+        {
+            transform.position = Vector3.Lerp(startPos, endPos, elapsed / duration);
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+
+        transform.position = endPos; // 최종 위치 보정
         currentTile = nextTile;
-        yield return new WaitForSeconds(1f);
+
+        _isMoving = false;
     }
+
+ 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#46 

## 📝작업 내용
- 플레이어의 타일 단위 이동에 Queue 사용했던 부분을 삭제하고 코루틴을 사용하여 한 타일씩 전달하도록 수정했습니다.
- 변수, 함수명의 표현을 변경하였습니다. 
  - gameTurn -> Round
   playerTurn -> Turn
   game -> BoardGame

## 💬리뷰 요구사항
BoardManager 의 coroutine에서 타일을 하나씩 전달하도록 수정했는데, 
<BoardManager가 다음 가야 할 타일 정보를 플레이어에게 전달 -> 플레이어 이동 완료 -> 그 다음 가야 할 타일 정보를 플레이어에게 전달.. 반복>
이 로직을 유지하는 더 좋은 코드 아이디어 떠오르시면 공유 부탁 드려요!!