### PR TITLE
[bug] 턴을 받은 플레이어 머리 위에 주사위 표시, 주사위 굴림시 주사위 오브젝트 비활성화 후 남은 이동 횟수 숫자로 출력

### DIFF
--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -158,30 +158,6 @@ public class BoardManager : Singleton<BoardManager>
         }
     }
 
-    //private void ProcessConfirmButton()
-    //{
-    //    _currentPlayer = _playerList[_currentPlayerIndex];
-    //    //_currentPlayer._dice.gameObject.SetActive(false);
-    //    ProcessTurn(_currentPlayer);
-    //    _currentPlayerIndex++;
-
-    //    if (_currentPlayerIndex == _playerList.Count)
-    //    {
-    //        _currentPlayerIndex = 0;
-    //        _currentRound++;
-    //    }
-
-    //    if (_currentRound == _maxRound)
-    //    {
-    //        _phaseMachine.ChangePhase(_endPhase);
-    //    }
-    //}
-
-    //private void ProcessTurn(Player currentPlayer)
-    //{
-    //    int playersDiceNum = _currentPlayer.RollDice(); //주사위 던지기
-    //    StartCoroutine(SendTileCo(currentPlayer, playersDiceNum)); //움직여
-    //}
     private void ProcessConfirmButton()
     {
         _currentPlayer = _playerList[_currentPlayerIndex];

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -23,7 +23,7 @@ public class Player : MonoBehaviour
     }
     public int RollDice()
     {
-        _dice.gameObject.SetActive(true);
+        _dice.gameObject.SetActive(false);
         return _dice.Roll();
     }
 
@@ -41,5 +41,35 @@ public class Player : MonoBehaviour
                         currentTile = nextTile;
                     });
         }
-    } 
+    }
+    public void TurnOnDiceNumber(int index)
+    {
+        foreach (var diceNumberObject in _diceNumberObjects)
+        {
+            diceNumberObject.SetActive(false);
+        }
+        if (_diceNumberObjects[index - 1] != null)
+        {
+            _diceNumberObjects[index - 1].SetActive(true);
+        }
+
+    }
+    public void TurnOffDiceNumber()
+    {
+        foreach (var diceNumberObject in _diceNumberObjects)
+        {
+            diceNumberObject.SetActive(false);
+        }
+
+    }
+    public void TurnOnDice()
+    {
+        _dice.gameObject.SetActive(true);
+        Animator diceAnimator = _dice.GetComponent<Animator>();
+        diceAnimator.speed = 20.0f;
+    }
+    public void TurnOffDice()
+    {
+        _dice.gameObject.SetActive(false);
+    }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -44,10 +44,8 @@ public class Player : MonoBehaviour
     }
     public void TurnOnDiceNumber(int index)
     {
-        foreach (var diceNumberObject in _diceNumberObjects)
-        {
-            diceNumberObject.SetActive(false);
-        }
+        TurnOffDiceNumber();
+
         if (_diceNumberObjects[index - 1] != null)
         {
             _diceNumberObjects[index - 1].SetActive(true);
@@ -65,8 +63,6 @@ public class Player : MonoBehaviour
     public void TurnOnDice()
     {
         _dice.gameObject.SetActive(true);
-        Animator diceAnimator = _dice.GetComponent<Animator>();
-        diceAnimator.speed = 20.0f;
     }
     public void TurnOffDice()
     {

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -816,7 +816,24 @@ PlayerSettings:
   webGLWebAssemblyBigInt: 0
   webGLCloseOnQuit: 0
   webWasm2023: 0
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    Android: DOTWEEN
+    EmbeddedLinux: DOTWEEN
+    GameCoreScarlett: DOTWEEN
+    GameCoreXboxOne: DOTWEEN
+    LinuxHeadlessSimulation: DOTWEEN
+    Nintendo Switch: DOTWEEN
+    PS4: DOTWEEN
+    PS5: DOTWEEN
+    QNX: DOTWEEN
+    ReservedCFE: DOTWEEN
+    Standalone: DOTWEEN
+    VisionOS: DOTWEEN
+    WebGL: DOTWEEN
+    Windows Store Apps: DOTWEEN
+    XboxOne: DOTWEEN
+    iPhone: DOTWEEN
+    tvOS: DOTWEEN
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend:


### PR DESCRIPTION
## #️⃣연관된 이슈

47 - 주사위 오브젝트 및 주사위값(남은 이동 횟수) 플레이어 머리 위에 출력

## 📝작업 내용

이제 턴을 정하는 단계에서 플레이어가 주사위 굴림을 수행할 경우, 머리 위 주사위가 비활성화됩니다.
턴을 받은 플레이어 머리 위엔 주사위가 표시됩니다
주사위를 굴릴 경우, 주사위가 사라지며 대신 남은 이동 횟수가 표시됩니다.
남은 이동 횟수는 주사위값으로 시작하여, 타일을 한 칸씩 옮길 때마다 하나씩 감소합니다.
