### PR TITLE
[Feature] Board Scene에 에셋 적용 및 애니메이션 작동

### DIFF
--- a/Assets/MeowrioAsset/Animation/Player.controller
+++ b/Assets/MeowrioAsset/Animation/Player.controller
@@ -1,5 +1,30 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-6337661303171717320
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isMoving
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3982946601502774659}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-5224275732236173873
 AnimatorState:
   serializedVersion: 6
@@ -10,7 +35,8 @@ AnimatorState:
   m_Name: PlayerJump
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 3848355640766649799}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -54,7 +80,8 @@ AnimatorStateMachine:
     m_State: {fileID: 6572705131284740859}
     m_Position: {x: 650, y: 120, z: 0}
   m_ChildStateMachines: []
-  m_AnyStateTransitions: []
+  m_AnyStateTransitions:
+  - {fileID: 5487550951401271916}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -89,6 +116,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-1797574380868917589
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isMoving
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 6572705131284740859}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9583333
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -97,7 +149,19 @@ AnimatorController:
   m_PrefabAsset: {fileID: 0}
   m_Name: Player
   serializedVersion: 5
-  m_AnimatorParameters: []
+  m_AnimatorParameters:
+  - m_Name: isMoving
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Jump
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -137,6 +201,28 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &3848355640766649799
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3982946601502774659}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.73214287
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &3982946601502774659
 AnimatorState:
   serializedVersion: 6
@@ -147,7 +233,8 @@ AnimatorState:
   m_Name: PlayerIdle
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: -1797574380868917589}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -189,6 +276,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &5487550951401271916
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Jump
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5224275732236173873}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &6572705131284740859
 AnimatorState:
   serializedVersion: 6
@@ -199,7 +311,8 @@ AnimatorState:
   m_Name: PlayerWalk
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: -6337661303171717320}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/MeowrioAsset/Player/Luigi.prefab
+++ b/Assets/MeowrioAsset/Player/Luigi.prefab
@@ -2637,7 +2637,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fb2358e472cfa67488a73a1ef38ec11e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerID: 0
+  playerID: 1
   _inputManager: {fileID: 11400000, guid: d47f0c20fe52b0f40a1474b9f2b13483, type: 2}
   currentTile: {fileID: 0}
   _dice: {fileID: 3547064571836856754}

--- a/Assets/MeowrioAsset/Tile/Tiles.prefab
+++ b/Assets/MeowrioAsset/Tile/Tiles.prefab
@@ -1,0 +1,565 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7369777001365720998
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8253204522225757929}
+  m_Layer: 0
+  m_Name: Tiles
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8253204522225757929
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7369777001365720998}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5453006313737900980}
+  - {fileID: 8000645626637774117}
+  - {fileID: 7401311373859613860}
+  - {fileID: 1019644491181643305}
+  - {fileID: 5975425073666249481}
+  - {fileID: 1491382445875930369}
+  - {fileID: 6111490569868067597}
+  - {fileID: 4127204653724735630}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1294752468917778476
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8253204522225757929}
+    m_Modifications:
+    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: tileIndex
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_Name
+      value: normalTile 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+--- !u!4 &8000645626637774117 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+  m_PrefabInstance: {fileID: 1294752468917778476}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1750034621624777133
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8253204522225757929}
+    m_Modifications:
+    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: tileIndex
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_Name
+      value: normalTile 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.381
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+--- !u!4 &7401311373859613860 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+  m_PrefabInstance: {fileID: 1750034621624777133}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3039791241169688068
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8253204522225757929}
+    m_Modifications:
+    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: tileIndex
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_Name
+      value: normalTile 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.381
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+--- !u!4 &6111490569868067597 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+  m_PrefabInstance: {fileID: 3039791241169688068}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3175912116699219456
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8253204522225757929}
+    m_Modifications:
+    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: tileIndex
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_Name
+      value: normalTile 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.381
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+--- !u!4 &5975425073666249481 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+  m_PrefabInstance: {fileID: 3175912116699219456}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3842443587529655997
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8253204522225757929}
+    m_Modifications:
+    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_Name
+      value: normalTile 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.381
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+--- !u!4 &5453006313737900980 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+  m_PrefabInstance: {fileID: 3842443587529655997}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5168202215344278919
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8253204522225757929}
+    m_Modifications:
+    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: tileIndex
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_Name
+      value: normalTile 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+--- !u!4 &4127204653724735630 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+  m_PrefabInstance: {fileID: 5168202215344278919}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7659943616664678408
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8253204522225757929}
+    m_Modifications:
+    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: tileIndex
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_Name
+      value: normalTile 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 17.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+--- !u!4 &1491382445875930369 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+  m_PrefabInstance: {fileID: 7659943616664678408}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8131639520391152416
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8253204522225757929}
+    m_Modifications:
+    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: tileIndex
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_Name
+      value: normalTile 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.10000038
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -11.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+--- !u!4 &1019644491181643305 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+  m_PrefabInstance: {fileID: 8131639520391152416}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/MeowrioAsset/Tile/Tiles.prefab.meta
+++ b/Assets/MeowrioAsset/Tile/Tiles.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6b1d8911e7139324e8a6b966f0299243
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MeowrioAsset/Tile/normalTile.prefab
+++ b/Assets/MeowrioAsset/Tile/normalTile.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 9151281785234101513}
   - component: {fileID: 5917183932549999484}
   - component: {fileID: 2568970418198401115}
-  - component: {fileID: 6770279843437382700}
   - component: {fileID: 4586547460464578106}
   - component: {fileID: -4162932433226052570}
   m_Layer: 0
@@ -89,28 +88,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!64 &6770279843437382700
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 923754175567157850}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 0
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!65 &4586547460464578106
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Board.unity
+++ b/Assets/Scenes/Board.unity
@@ -26,7 +26,7 @@ RenderSettings:
   m_AmbientIntensity: 1
   m_AmbientMode: 0
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
-  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_SkyboxMaterial: {fileID: 2100000, guid: 656058fe318eb48558d21d66d1a79a2b, type: 2}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3
@@ -134,7 +134,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &252009639
 Transform:
   m_ObjectHideFlags: 0
@@ -158,6 +158,32 @@ Transform:
   - {fileID: 1843111678}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &410796301 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1834276490021983613, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+  m_PrefabInstance: {fileID: 1691999655}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &410796302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410796301}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f771882c456642f48b9653e516210812, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tiles:
+  - {fileID: 1658978519}
+  - {fileID: 2082964529}
+  - {fileID: 1910463252}
+  - {fileID: 914575283}
+  - {fileID: 1827149169}
+  - {fileID: 685024308}
+  - {fileID: 1700026876}
+  - {fileID: 1480609319}
 --- !u!1001 &514935792
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -235,17 +261,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &610873985 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8613348121097284209, guid: 35689aae04913224d8356c024bb7f508, type: 3}
-  m_PrefabInstance: {fileID: 5149568943204046300}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fb2358e472cfa67488a73a1ef38ec11e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &643203362
 GameObject:
   m_ObjectHideFlags: 0
@@ -292,6 +307,17 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &685024308 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3204272791743003694, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 882153069}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &725075760
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -446,6 +472,63 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &882153069
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7369777001365720998, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_Name
+      value: Tiles (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
 --- !u!1001 &902997188
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -498,6 +581,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8530428331039964353, guid: 35689aae04913224d8356c024bb7f508, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8613348121097284209, guid: 35689aae04913224d8356c024bb7f508, type: 3}
       propertyPath: playerID
       value: 1
@@ -511,6 +598,78 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 35689aae04913224d8356c024bb7f508, type: 3}
+--- !u!114 &914575283 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3955048935871647494, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 882153069}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &936888905
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3006416899135075152, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: currentTile
+      value: 
+      objectReference: {fileID: 1658978519}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.3902359
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.78
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 3611700556431245001, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8060592879526011340, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+      propertyPath: m_Name
+      value: Mario
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
 --- !u!1 &956446942
 GameObject:
   m_ObjectHideFlags: 0
@@ -544,9 +703,9 @@ MonoBehaviour:
   _maxRound: 0
   _currentRound: 0
   _playerList:
-  - {fileID: 610873985}
-  - {fileID: 1572967920}
-  _board: {fileID: 2072996420}
+  - {fileID: 1725857389}
+  - {fileID: 1953368240}
+  _board: {fileID: 410796302}
   _currentPlayer: {fileID: 0}
 --- !u!4 &956446944
 Transform:
@@ -633,6 +792,90 @@ Transform:
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1083857072935610095, guid: 3a837cfce001da1418748ba17e2eae1b, type: 3}
   m_PrefabInstance: {fileID: 1063855098}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1434021168
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245321843144180702, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5150105546979060449, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5150105546979060449, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5150105546979060449, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5150105546979060449, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9156810553894577742, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+      propertyPath: m_Name
+      value: UIManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 41190817992cb1e408d484b77687eaa2, type: 3}
+--- !u!114 &1480609319 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 109053455580021153, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 882153069}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -761,17 +1004,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!114 &1572967920 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8613348121097284209, guid: 35689aae04913224d8356c024bb7f508, type: 3}
-  m_PrefabInstance: {fileID: 902997188}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fb2358e472cfa67488a73a1ef38ec11e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1613125828
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -854,6 +1086,171 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7582726601114176592, guid: 3a837cfce001da1418748ba17e2eae1b, type: 3}
   m_PrefabInstance: {fileID: 2379648074971992830}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1658978519 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8316267348922534555, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 882153069}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1691999655
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1834276490021983613, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_Name
+      value: Map
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6955275051700256175, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 1834276490021983613, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 410796302}
+  m_SourcePrefab: {fileID: 100100000, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
+--- !u!114 &1700026876 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7788352155342641698, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 882153069}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1725857389 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3006416899135075152, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+  m_PrefabInstance: {fileID: 936888905}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb2358e472cfa67488a73a1ef38ec11e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1827149169 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7649733661837527590, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 882153069}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1841629138
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1319845042489542728, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: currentTile
+      value: 
+      objectReference: {fileID: 1658978519}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -16.53816
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.3902359
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.703763
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 4042943520160654300, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4280275881824714981, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+      propertyPath: m_Name
+      value: Luigi
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
 --- !u!1001 &1843111677
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -924,6 +1321,17 @@ Transform:
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1083857072935610095, guid: 3a837cfce001da1418748ba17e2eae1b, type: 3}
   m_PrefabInstance: {fileID: 1843111677}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1910463252 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6805805681012094347, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 882153069}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -1087,6 +1495,17 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1953368240 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1319845042489542728, guid: ccff55c4e3cc52b4da3b9427a07d18ea, type: 3}
+  m_PrefabInstance: {fileID: 1841629138}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb2358e472cfa67488a73a1ef38ec11e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1964758993
 GameObject:
   m_ObjectHideFlags: 0
@@ -1173,8 +1592,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1964758993}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.4910501, y: 0.005746743, z: -0.0032374468, w: -0.8711064}
-  m_LocalPosition: {x: -0.19604746, y: 9.012156, z: -6.9687014}
+  m_LocalRotation: {x: 0.002719198, y: 0.89095783, z: -0.45404658, w: 0.005333809}
+  m_LocalPosition: {x: -2.0917187, y: 38.589134, z: 39.009125}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1243,7 +1662,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!65 &2072996416
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1354,223 +1773,17 @@ MonoBehaviour:
   - {fileID: 1931478846}
   - {fileID: 725075762}
   - {fileID: 1843111679}
---- !u!1 &136830271752479555
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2690572772979843719}
-  m_Layer: 5
-  m_Name: NoticeUI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!222 &417076418271829347
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6733642523722204422}
-  m_CullTransparentMesh: 1
---- !u!222 &595323166346539823
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7777446333241378824}
-  m_CullTransparentMesh: 1
---- !u!1 &1031671955473029073
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2278122054545669452}
-  - component: {fileID: 1132374828100808435}
-  - component: {fileID: 2798702847748902529}
-  - component: {fileID: 1790430506260088562}
-  m_Layer: 5
-  m_Name: DiceButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!222 &1132374828100808435
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1031671955473029073}
-  m_CullTransparentMesh: 1
---- !u!114 &1790430506260088562
+--- !u!114 &2082964529 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6326899421438850058, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 882153069}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1031671955473029073}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 2798702847748902529}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!224 &1955968559682717727
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6587873075116668947}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2209571444201862827}
-  m_Father: {fileID: 6047309368861427105}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -298, y: -150}
-  m_SizeDelta: {x: 300, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &1998238051888201743
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6622391880697753653}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4757875269224887309}
-  m_Father: {fileID: 8808339657881100388}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -110}
-  m_SizeDelta: {x: 200, y: 200}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &2037739895546116479
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3962880052413851472}
-  m_CullTransparentMesh: 1
---- !u!222 &2084307100863951862
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7036549934868031922}
-  m_CullTransparentMesh: 1
---- !u!224 &2169502732493692176
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3962880052413851472}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7830460118119223958}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &2209571444201862827
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6733642523722204422}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1955968559682717727}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &2278122054545669452
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1031671955473029073}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8046152414249081551}
-  m_Father: {fileID: 6047309368861427105}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -300, y: -35}
-  m_SizeDelta: {x: 300, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &2379648074971992830
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1639,86 +1852,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!224 &2690572772979843719
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 136830271752479555}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7830460118119223958}
-  m_Father: {fileID: 8808339657881100388}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2798702847748902529
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1031671955473029073}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.2}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &3365423144053809157
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8558221999815440595}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.392}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &3442330019787212704
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1780,210 +1913,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a6f974d2cc4cdde418c2fc624372285e, type: 3}
---- !u!1 &3962880052413851472
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2169502732493692176}
-  - component: {fileID: 2037739895546116479}
-  - component: {fileID: 8694185580409397954}
-  m_Layer: 5
-  m_Name: Text (TMP)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &4072802364868974030
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7777446333241378824}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 1769939207, guid: 7cfd565f8c6b8794b8389f35238e5011, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &4342775902590964008
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6587873075116668947}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.2}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &4544398300727794625
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7036549934868031922}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: "\uC8FC\uC0AC\uC704\n"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 1e83d23323b77814c8cf28a41d6defdd, type: 2}
-  m_sharedMaterial: {fileID: 4374449736787908223, guid: 1e83d23323b77814c8cf28a41d6defdd, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 0
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0.9684067, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!224 &4757875269224887309
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7777446333241378824}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1998238051888201743}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 150, y: 256}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &5045788316752002874
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6047309368861427105}
-  m_Layer: 5
-  m_Name: Temp_SelectActionUI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1001 &5149568943204046300
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2056,6 +1985,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8530428331039964353, guid: 35689aae04913224d8356c024bb7f508, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8613348121097284209, guid: 35689aae04913224d8356c024bb7f508, type: 3}
       propertyPath: currentTile
       value: 
@@ -2065,534 +1998,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 35689aae04913224d8356c024bb7f508, type: 3}
---- !u!222 &5393460824336058560
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6587873075116668947}
-  m_CullTransparentMesh: 1
---- !u!224 &6047309368861427105
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5045788316752002874}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2278122054545669452}
-  - {fileID: 1955968559682717727}
-  m_Father: {fileID: 8808339657881100388}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 390, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0, y: 0.5}
---- !u!1 &6587873075116668947
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1955968559682717727}
-  - component: {fileID: 5393460824336058560}
-  - component: {fileID: 4342775902590964008}
-  - component: {fileID: 7213245353617763846}
-  m_Layer: 5
-  m_Name: ItemButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &6622391880697753653
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1998238051888201743}
-  m_Layer: 5
-  m_Name: DiceNumberUI
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &6674609997004846525
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7924566288919168474}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!1 &6733642523722204422
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2209571444201862827}
-  - component: {fileID: 417076418271829347}
-  - component: {fileID: 8814077211530978026}
-  m_Layer: 5
-  m_Name: ItemText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7036549934868031922
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8046152414249081551}
-  - component: {fileID: 2084307100863951862}
-  - component: {fileID: 4544398300727794625}
-  m_Layer: 5
-  m_Name: DiceText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &7213245353617763846
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6587873075116668947}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 4342775902590964008}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
---- !u!1 &7777446333241378824
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4757875269224887309}
-  - component: {fileID: 595323166346539823}
-  - component: {fileID: 4072802364868974030}
-  m_Layer: 5
-  m_Name: DiceNumberImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &7830460118119223958
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8558221999815440595}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2169502732493692176}
-  m_Father: {fileID: 2690572772979843719}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 156}
-  m_SizeDelta: {x: 0, y: 200}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &7924566288919168474
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8808339657881100388}
-  - component: {fileID: 8120320469660693515}
-  - component: {fileID: 8530201560794661076}
-  - component: {fileID: 6674609997004846525}
-  - component: {fileID: 8808339657881100389}
-  m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8046152414249081551
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7036549934868031922}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2278122054545669452}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!223 &8120320469660693515
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7924566288919168474}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &8530201560794661076
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7924566288919168474}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1920, y: 1080}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!1 &8558221999815440595
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7830460118119223958}
-  - component: {fileID: 8730349635031974921}
-  - component: {fileID: 3365423144053809157}
-  m_Layer: 5
-  m_Name: Panel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &8694185580409397954
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3962880052413851472}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: "\uD50C\uB808\uC774\uC5B41 \uC2A4\uD0C0\uD2B8"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 1e83d23323b77814c8cf28a41d6defdd, type: 2}
-  m_sharedMaterial: {fileID: 4374449736787908223, guid: 1e83d23323b77814c8cf28a41d6defdd, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &8730349635031974921
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8558221999815440595}
-  m_CullTransparentMesh: 1
---- !u!224 &8808339657881100388
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7924566288919168474}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2690572772979843719}
-  - {fileID: 1998238051888201743}
-  - {fileID: 6047309368861427105}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
---- !u!114 &8808339657881100389
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7924566288919168474}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 44313ad1e5e9d7545b85d345a2c7f918, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _rollDiceButton: {fileID: 1790430506260088562}
-  _onRollButtonClicked: {fileID: 11400000, guid: 1c0a750c9fc08654aa70c3cc860fdca6, type: 2}
---- !u!114 &8814077211530978026
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6733642523722204422}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: "\uC544\uC774\uD15C"
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 1e83d23323b77814c8cf28a41d6defdd, type: 2}
-  m_sharedMaterial: {fileID: 4374449736787908223, guid: 1e83d23323b77814c8cf28a41d6defdd, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 0
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0.9684067, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -2600,11 +2005,15 @@ SceneRoots:
   - {fileID: 1964758996}
   - {fileID: 1565444872}
   - {fileID: 252009639}
-  - {fileID: 5149568943204046300}
-  - {fileID: 902997188}
   - {fileID: 2072996419}
   - {fileID: 643203364}
   - {fileID: 3442330019787212704}
+  - {fileID: 5149568943204046300}
+  - {fileID: 902997188}
   - {fileID: 956446944}
-  - {fileID: 8808339657881100388}
   - {fileID: 1940745560}
+  - {fileID: 1691999655}
+  - {fileID: 882153069}
+  - {fileID: 936888905}
+  - {fileID: 1841629138}
+  - {fileID: 1434021168}

--- a/Assets/Scenes/ProtoTypeScene.unity
+++ b/Assets/Scenes/ProtoTypeScene.unity
@@ -130,72 +130,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fb2358e472cfa67488a73a1ef38ec11e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &547527480
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1681851631}
-    m_Modifications:
-    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: tileIndex
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_Name
-      value: normalTile 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.10000038
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
---- !u!4 &547527481 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 547527480}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &587055073
 GameObject:
   m_ObjectHideFlags: 0
@@ -275,72 +209,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &648084828
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1681851631}
-    m_Modifications:
-    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: tileIndex
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_Name
-      value: normalTile 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 17.93
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
---- !u!4 &648084829 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 648084828}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &745212562
 GameObject:
   m_ObjectHideFlags: 0
@@ -734,76 +602,10 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1000169240}
   m_CullTransparentMesh: 1
---- !u!1001 &1092020627
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1681851631}
-    m_Modifications:
-    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: tileIndex
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_Name
-      value: normalTile 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.97
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
---- !u!4 &1092020628 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1092020627}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1092020629 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1092020627}
+  m_CorrespondingSourceObject: {fileID: 109053455580021153, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 4446148959485649483}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -844,7 +646,7 @@ MonoBehaviour:
   _maxRound: 2
   _currentRound: 0
   _playerList:
-  - {fileID: 0}
+  - {fileID: 2128528934}
   - {fileID: 316288897}
   _board: {fileID: 1910009026}
   _currentPlayer: {fileID: 0}
@@ -863,76 +665,10 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1203904639
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1681851631}
-    m_Modifications:
-    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: tileIndex
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_Name
-      value: normalTile 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -18.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
---- !u!4 &1203904640 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1203904639}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1203904645 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1203904639}
+  m_CorrespondingSourceObject: {fileID: 6326899421438850058, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 4446148959485649483}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -1304,8 +1040,8 @@ CanvasRenderer:
   m_CullTransparentMesh: 1
 --- !u!114 &1398433101 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 547527480}
+  m_CorrespondingSourceObject: {fileID: 3955048935871647494, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 4446148959485649483}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -1313,76 +1049,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ba8eb544decd94c44b8c95b4ffd7c1e8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &1443801627
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1681851631}
-    m_Modifications:
-    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: tileIndex
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_Name
-      value: normalTile 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 17.93
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.381
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
---- !u!4 &1443801628 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1443801627}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1443801633 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1443801627}
+  m_CorrespondingSourceObject: {fileID: 7649733661837527590, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 4446148959485649483}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -1526,115 +1196,10 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1663476640}
   m_CullTransparentMesh: 1
---- !u!1 &1681851630
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1681851631}
-  m_Layer: 0
-  m_Name: Tiles
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1681851631
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1681851630}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5080000839019808963}
-  - {fileID: 1203904640}
-  - {fileID: 1722383340}
-  - {fileID: 547527481}
-  - {fileID: 1443801628}
-  - {fileID: 648084829}
-  - {fileID: 1887885679}
-  - {fileID: 1092020628}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1722383339
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1681851631}
-    m_Modifications:
-    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: tileIndex
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_Name
-      value: normalTile 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -18.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.381
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
---- !u!4 &1722383340 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1722383339}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1722383345 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1722383339}
+  m_CorrespondingSourceObject: {fileID: 6805805681012094347, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 4446148959485649483}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -1912,76 +1477,10 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1836108469}
   m_CullTransparentMesh: 1
---- !u!1001 &1887885678
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1681851631}
-    m_Modifications:
-    - target: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: tileIndex
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_Name
-      value: normalTile 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 17.93
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.381
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 10.97
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
---- !u!4 &1887885679 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1887885678}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1887885684 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 1887885678}
+  m_CorrespondingSourceObject: {fileID: 7788352155342641698, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 4446148959485649483}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -2055,8 +1554,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!114 &2024130150 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 648084828}
+  m_CorrespondingSourceObject: {fileID: 3204272791743003694, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 4446148959485649483}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -2233,8 +1732,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 44313ad1e5e9d7545b85d345a2c7f918, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _rollDiceButton: {fileID: 822562918}
-  _onRollButtonClicked: {fileID: 11400000, guid: 1c0a750c9fc08654aa70c3cc860fdca6, type: 2}
 --- !u!114 &2101797653
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2320,6 +1817,17 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!114 &2128528934 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3006416899135075152, guid: 56bcd39af262fef4f8e031b3ef6bbced, type: 3}
+  m_PrefabInstance: {fileID: 1739783582}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb2358e472cfa67488a73a1ef38ec11e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &897456718235373383
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4974,55 +4482,55 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7147b3cb278902b4c8be0a82c006be05, type: 3}
---- !u!1001 &5080000839019808962
+--- !u!1001 &4446148959485649483
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1681851631}
+    m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 923754175567157850, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 7369777001365720998, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_Name
-      value: normalTile 0
+      value: Tiles
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -18.04
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.381
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 10.97
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
+    - target: {fileID: 8253204522225757929, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -5030,16 +4538,11 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
---- !u!4 &5080000839019808963 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 9151281785234101513, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 5080000839019808962}
-  m_PrefabAsset: {fileID: 0}
+  m_SourcePrefab: {fileID: 100100000, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
 --- !u!114 &5080000839019808968 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: -4162932433226052570, guid: ee4717218f5e94e4fafb948ade2b0265, type: 3}
-  m_PrefabInstance: {fileID: 5080000839019808962}
+  m_CorrespondingSourceObject: {fileID: 8316267348922534555, guid: 6b1d8911e7139324e8a6b966f0299243, type: 3}
+  m_PrefabInstance: {fileID: 4446148959485649483}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
@@ -5056,7 +4559,7 @@ SceneRoots:
   - {fileID: 1100622603}
   - {fileID: 1910009027}
   - {fileID: 897456718235373383}
-  - {fileID: 1681851631}
+  - {fileID: 4446148959485649483}
   - {fileID: 1739783582}
   - {fileID: 1252235896}
   - {fileID: 2101797656}

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using DG.Tweening;
+using System;
 // COMMENT : 플레이어 이동과 관련된 로직만 처리하면 됨
 // COMMENT : BoardManager가 가야할 Tile을 알려줌
 
@@ -20,6 +21,8 @@ public class Player : MonoBehaviour
 
     public bool IsMoving { get { return _isMoving; } }
 
+    private Animator _animator;
+
     private void OnEnable()
     {
         _inputManager.OnDiceButtonPerformed += OnDiceInputReceived;
@@ -32,10 +35,12 @@ public class Player : MonoBehaviour
     void Start()
     {
         DOTween.Init(false, true, LogBehaviour.Verbose).SetCapacity(200, 50);
+        _animator = GetComponent<Animator>();
     }
     public int RollDice()
     {
         _dice.gameObject.SetActive(false);
+        _animator.SetTrigger("Jump");
         return _dice.Roll();
     }
 
@@ -44,13 +49,20 @@ public class Player : MonoBehaviour
         if (!_isMoving)
         {
             _isMoving = true;
+            _animator.SetBool("isMoving", true);
             Vector3 endPos = nextTile.transform.position;
+            Vector3 direction = (endPos - transform.position).normalized;
+            direction.y = 0f;
+            transform.DOLookAt(endPos, 0.2f);
+
             transform.DOMove(endPos, moveSpeed)
                     .SetEase(Ease.Linear)
                     .OnComplete(() =>
                     {
                         _isMoving = false;
                         currentTile = nextTile;
+
+                        _animator.SetBool("isMoving", false);
                     });
         }
     }
@@ -88,5 +100,5 @@ public class Player : MonoBehaviour
             return;
         }
         BoardManager.Instance.OnPlayersInput(this);
-    }
+    }    
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -23,6 +23,11 @@ public class Player : MonoBehaviour
 
     private Animator _animator;
 
+    private void Awake()
+    {
+        _animator = GetComponent<Animator>();
+    }
+
     private void OnEnable()
     {
         _inputManager.OnDiceButtonPerformed += OnDiceInputReceived;
@@ -35,8 +40,8 @@ public class Player : MonoBehaviour
     void Start()
     {
         DOTween.Init(false, true, LogBehaviour.Verbose).SetCapacity(200, 50);
-        _animator = GetComponent<Animator>();
     }
+
     public int RollDice()
     {
         _dice.gameObject.SetActive(false);

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ai.navigation": "2.0.5",
+    "com.unity.cinemachine": "3.1.3",
     "com.unity.collab-proxy": "2.6.0",
     "com.unity.ide.rider": "3.0.31",
     "com.unity.ide.visualstudio": "2.0.22",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -25,6 +25,16 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.cinemachine": {
+      "version": "3.1.3",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.splines": "2.0.0",
+        "com.unity.modules.imgui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.collab-proxy": {
       "version": "2.6.0",
       "depth": 0,
@@ -150,6 +160,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.settings-manager": {
+      "version": "2.0.1",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.shadergraph": {
       "version": "17.0.3",
       "depth": 1,
@@ -158,6 +175,16 @@
         "com.unity.render-pipelines.core": "17.0.3",
         "com.unity.searcher": "4.9.2"
       }
+    },
+    "com.unity.splines": {
+      "version": "2.7.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.mathematics": "1.2.1",
+        "com.unity.settings-manager": "1.0.3"
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
       "version": "1.4.5",


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #65 

## 📝작업 내용

> 여태 작업했던 Board Scene에 맵, 플레이어 에셋을 입히고 애니메이션 작동되게 플레이어.cs를 수정했습니다.
플레이어가 이동할 때 목표 타일을 향해 걸어가며 보는 방향도 같이 돌아갑니다.

## 💬리뷰 요구사항(선택)

> 플레이어가 점프와 동시에 주사위를 굴리고 기다린 다음 이동하게 하고 싶은데 잘 되지 않았습니다. 좀 더 찾아봐야 할 것 같습니다.
