### PR TITLE
[Refactor]  NetworkManager 내부의 데이터 사용으로 변경

### DIFF
--- a/Assets/Prefabs/NetworkTestPrefabs/NetTestLuigi.prefab
+++ b/Assets/Prefabs/NetworkTestPrefabs/NetTestLuigi.prefab
@@ -1074,6 +1074,7 @@ GameObject:
   - component: {fileID: 8293379854018032003}
   - component: {fileID: 4532040618021073130}
   - component: {fileID: 4895522600493578644}
+  - component: {fileID: 1894659578578736586}
   m_Layer: 0
   m_Name: NetTestLuigi
   m_TagString: Untagged
@@ -1271,6 +1272,21 @@ MonoBehaviour:
   SwitchTransformSpaceWhenParented: 0
   Interpolate: 0
   SlerpPosition: 0
+--- !u!114 &1894659578578736586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1686880860600399186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e8d0727d5ae3244e3b569694d3912374, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+  TransitionStateInfoList: []
+  m_Animator: {fileID: 5798041432711524303}
 --- !u!1 &1854675282673894403
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/NetworkTestPrefabs/NetTestMario.prefab
+++ b/Assets/Prefabs/NetworkTestPrefabs/NetTestMario.prefab
@@ -2388,6 +2388,7 @@ GameObject:
   - component: {fileID: 2901805762319138318}
   - component: {fileID: 5409618754797890112}
   - component: {fileID: 3761846564083091350}
+  - component: {fileID: 6330585106149215780}
   m_Layer: 0
   m_Name: NetTestMario
   m_TagString: Untagged
@@ -2586,6 +2587,21 @@ MonoBehaviour:
   SwitchTransformSpaceWhenParented: 0
   Interpolate: 0
   SlerpPosition: 0
+--- !u!114 &6330585106149215780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3229872934675508115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e8d0727d5ae3244e3b569694d3912374, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowTopMostFoldoutHeaderGroup: 1
+  TransitionStateInfoList: []
+  m_Animator: {fileID: 723349993674084317}
 --- !u!1 &3454982103157592275
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Prototype/BoardManager.prefab
+++ b/Assets/Prefabs/Prototype/BoardManager.prefab
@@ -45,7 +45,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 225289333
+  GlobalObjectIdHash: 4095548497
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1
@@ -72,11 +72,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ShowTopMostFoldoutHeaderGroup: 1
   inputManager: {fileID: 11400000, guid: d47f0c20fe52b0f40a1474b9f2b13483, type: 2}
+  _currentState:
+    m_InternalValue: 0
   _maxRound: 0
   _currentRound: 0
-  _playerList:
-  - {fileID: 0}
-  - {fileID: 0}
   _board: {fileID: 0}
-  _currentPlayer: {fileID: 0}
-  characterList: []
+  _currentPlayerId: 0
+  _canInput: 0
+  _spawnPointList: []
+  characterPrefabList:
+  - {fileID: 1686880860600399186, guid: 642952c41553c514e864700dfe6e4633, type: 3}
+  - {fileID: 3229872934675508115, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}

--- a/Assets/Scenes/Board.unity
+++ b/Assets/Scenes/Board.unity
@@ -1773,31 +1773,31 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3770244978903609625, guid: 6ac3649e54a1ec5489225bbdd7c0d232, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.38944018
+      value: -18.176506
       objectReference: {fileID: 0}
     - target: {fileID: 3770244978903609625, guid: 6ac3649e54a1ec5489225bbdd7c0d232, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 21.138128
+      value: 0.8313713
       objectReference: {fileID: 0}
     - target: {fileID: 3770244978903609625, guid: 6ac3649e54a1ec5489225bbdd7c0d232, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 5.8292804
+      value: 13.8165245
       objectReference: {fileID: 0}
     - target: {fileID: 3770244978903609625, guid: 6ac3649e54a1ec5489225bbdd7c0d232, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.00047150432
+      value: -0.00087559724
       objectReference: {fileID: 0}
     - target: {fileID: 3770244978903609625, guid: 6ac3649e54a1ec5489225bbdd7c0d232, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.00038188332
+      value: -0.00017897447
       objectReference: {fileID: 0}
     - target: {fileID: 3770244978903609625, guid: 6ac3649e54a1ec5489225bbdd7c0d232, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.7786347
+      value: -0.9779661
       objectReference: {fileID: 0}
     - target: {fileID: 3770244978903609625, guid: 6ac3649e54a1ec5489225bbdd7c0d232, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.62747717
+      value: 0.20876192
       objectReference: {fileID: 0}
     - target: {fileID: 5227898324358821237, guid: 6ac3649e54a1ec5489225bbdd7c0d232, type: 3}
       propertyPath: m_Name
@@ -2303,91 +2303,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dabdd04c2d33f8142822d291fc78b6c3, type: 3}
---- !u!1001 &2890580852716590231
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1686880860600399186, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_Name
-      value: Luigi
-      objectReference: {fileID: 0}
-    - target: {fileID: 1686880860600399186, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4532040618021073130, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: currentTile
-      value: 
-      objectReference: {fileID: 1658978519}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -16.53816
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.3902359
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 12.703763
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 5304221399635269514, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8121506418843214449, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 3619588142
-      objectReference: {fileID: 0}
-    - target: {fileID: 8121506418843214449, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: SceneMigrationSynchronization
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8121506418843214449, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: InScenePlacedSourceGlobalObjectIdHash
-      value: 2878667068
-      objectReference: {fileID: 0}
-    - target: {fileID: 8293379854018032003, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 2883511507
-      objectReference: {fileID: 0}
-    - target: {fileID: 8293379854018032003, guid: 642952c41553c514e864700dfe6e4633, type: 3}
-      propertyPath: InScenePlacedSourceGlobalObjectIdHash
-      value: 2878667068
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 642952c41553c514e864700dfe6e4633, type: 3}
 --- !u!1001 &3442330019787212704
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2449,91 +2364,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a6f974d2cc4cdde418c2fc624372285e, type: 3}
---- !u!1001 &5118721445039001729
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2901805762319138318, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 494865994
-      objectReference: {fileID: 0}
-    - target: {fileID: 2901805762319138318, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: InScenePlacedSourceGlobalObjectIdHash
-      value: 1592875451
-      objectReference: {fileID: 0}
-    - target: {fileID: 3229872934675508115, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_Name
-      value: Mario
-      objectReference: {fileID: 0}
-    - target: {fileID: 3229872934675508115, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3457294259889468179, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: GlobalObjectIdHash
-      value: 3296703232
-      objectReference: {fileID: 0}
-    - target: {fileID: 3457294259889468179, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: SceneMigrationSynchronization
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3457294259889468179, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: InScenePlacedSourceGlobalObjectIdHash
-      value: 1592875451
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -19.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.3902359
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 11.72
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733178886578494706, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5409618754797890112, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
-      propertyPath: currentTile
-      value: 
-      objectReference: {fileID: 1658978519}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 346325d38d104e44d98a4963703d0e8a, type: 3}
 --- !u!1001 &5149568943204046300
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2634,8 +2464,6 @@ SceneRoots:
   - {fileID: 1940745560}
   - {fileID: 1691999655}
   - {fileID: 882153069}
-  - {fileID: 5118721445039001729}
-  - {fileID: 2890580852716590231}
   - {fileID: 1434021168}
   - {fileID: 2393696301632746130}
   - {fileID: 2035150710}

--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -100,7 +100,7 @@ public class BoardManager : NetSingleton<BoardManager>
             Debug.Log("cliendId : " + clientId + ", diceValue : " + diceValue);
 
             //주사위 숫자 연출 (주사위 off / 숫자 Sprite 출력)
-            TogglePlayerDiceRpc(clientId, false);
+            RollDiceSequenceRpc(clientId, diceValue);
 
             if (_playerDiceNumberList.All(p => p.Value != -1))
             {
@@ -130,6 +130,12 @@ public class BoardManager : NetSingleton<BoardManager>
 
             StartCoroutine(SendTileCo(_turnOrder[_currentPlayerIndex], diceValue));
         }
+    }
+
+    [Rpc(SendTo.Server)]
+    private void RollDiceSequenceRpc(ulong clientId, int diceValue)
+    {
+        TogglePlayerDiceRpc(clientId, false);
     }
 
     [Rpc(SendTo.ClientsAndHost)]

--- a/Assets/Scripts/BoardManager.cs
+++ b/Assets/Scripts/BoardManager.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Netcode;
-using UnityEditor.PackageManager;
 using UnityEngine;
 
 public enum GameState
@@ -20,11 +19,9 @@ public class BoardManager : NetSingleton<BoardManager>
     [SerializeField] private int _maxRound;
     [SerializeField] private int _currentRound;
 
-    [SerializeField] private Dictionary<ulong, Player> _connectedClients = new Dictionary<ulong, Player>(); //연결된 클라이언트들
     [SerializeField] private NetworkList<ulong> _turnOrder; //순서 정해서 여기에 넣기 
 
     [SerializeField] private Board _board;
-    //[SerializeField] private Player _currentPlayer;
     [SerializeField] private ulong _currentPlayerId;
     [SerializeField] private bool _canInput = false;
 
@@ -33,11 +30,8 @@ public class BoardManager : NetSingleton<BoardManager>
 
     [SerializeField] private List<GameObject> _spawnPointList;
 
-
-
     //temporary
-    public List<GameObject> characterList;
-    private Dictionary<ulong, int> _clientPrefabMap = new();
+    public List<GameObject> characterPrefabList;
 
     public override void Awake()
     {
@@ -84,22 +78,12 @@ public class BoardManager : NetSingleton<BoardManager>
 
         int prefabIndex = NetworkManager.Singleton.ConnectedClientsList.Count - 1;
         Vector3 spawnPos = _spawnPointList[prefabIndex].transform.position;
-        GameObject playerObj = Instantiate(characterList[prefabIndex], spawnPos, Quaternion.identity);
+        GameObject playerObj = Instantiate(characterPrefabList[prefabIndex], spawnPos, Quaternion.identity);
         playerObj.GetComponent<NetworkObject>().SpawnAsPlayerObject(clientId, true);
 
         Player player = playerObj.GetComponent<Player>();
-        player.ClientId.Value = clientId;
         player.currentTile = _board.tiles[0];
-        _connectedClients[clientId] = player;
-        _playerDiceNumberList[clientId] = -1; //주사위 안 굴림
-        Debug.Log(_connectedClients.Count);
-    }
-
-    [ServerRpc(RequireOwnership = false)]
-    public void RegisterCharacterServerRpc(int selectedIndex, ServerRpcParams rpcParams = default)
-    {
-        ulong clientId = rpcParams.Receive.SenderClientId;
-        _clientPrefabMap[clientId] = selectedIndex;
+        _playerDiceNumberList[clientId] = -1;
     }
 
     [Rpc(SendTo.Server)] //클 -> 서 주사위 굴려줘
@@ -116,7 +100,7 @@ public class BoardManager : NetSingleton<BoardManager>
             Debug.Log("cliendId : " + clientId + ", diceValue : " + diceValue);
 
             //주사위 숫자 연출 (주사위 off / 숫자 Sprite 출력)
-            RollDiceSequenceRpc(clientId, diceValue);
+            TogglePlayerDiceRpc(clientId, false);
 
             if (_playerDiceNumberList.All(p => p.Value != -1))
             {
@@ -125,9 +109,9 @@ public class BoardManager : NetSingleton<BoardManager>
                 _currentPlayerId = _turnOrder[0];
 
                 //Player들 시작 타일로 이동
-                foreach(var clientPair in _connectedClients)
+                foreach (var connectedClient in NetworkManager.Singleton.ConnectedClients)
                 {
-                    clientPair.Value.gameObject.transform.position = _board.tiles[0].transform.position;
+                    connectedClient.Value.PlayerObject.transform.position = _board.tiles[0].transform.position;
                 }
 
                 //첫번째 턴 Player의 정면 카메라 On
@@ -148,62 +132,22 @@ public class BoardManager : NetSingleton<BoardManager>
         }
     }
 
-    [Rpc(SendTo.Server)]
-    private void RollDiceSequenceRpc(ulong clientId, int diceValue)
-    {
-        _connectedClients.TryGetValue(clientId, out Player player); //되나?..
-
-        TogglePlayerDiceRpc(clientId, false);
-    }
-
     [Rpc(SendTo.ClientsAndHost)]
     private void TogglePlayerDiceRpc(ulong clientId, bool isOn)
     {
-        Player[] players = GameObject.FindObjectsByType<Player>(FindObjectsSortMode.None);
-
-        foreach (Player player in players)
-        {
-            if (player.ClientId.Value == clientId)
-            {
-                player._dice.gameObject.SetActive(isOn);
-                //숫자 스프라이트 뿅
-            }
-        }
+        var player = NetworkManager.Singleton.ConnectedClients[clientId].PlayerObject.GetComponent<Player>();
+        player._dice.gameObject.SetActive(isOn);
     }
 
     private void SetTurnOrder()
     {
         var sorted = _playerDiceNumberList.OrderByDescending(p => p.Value).ToList();
-
         _turnOrder.Clear();
         foreach (var tempDic in sorted)
         {
             _turnOrder.Add(tempDic.Key);
         }
     }
-
-    // private void ProcessConfirmButton()
-    // {
-    //     _currentPlayerId = _playerList[_currentPlayerIndex];
-
-    //     _currentPlayerId.TurnOffDice(); // 주사위 끄기
-    //     int playersDiceNum = _currentPlayerId.RollDice(); // 주사위 굴리기
-    //     StartCoroutine(SendTileCo(_currentPlayerId, playersDiceNum)); // 이동 시작
-
-    //     _currentPlayerIndex++;
-
-    //     if (_currentPlayerIndex == _playerList.Count)
-    //     {
-    //         _currentPlayerIndex = 0;
-    //         _currentRound++;
-    //     }
-
-    //     if (_currentRound == _maxRound)
-    //     {
-    //         _phaseMachine.ChangePhaseRpc(_endPhase);
-    //     }
-    // }
-
     private bool IsPlayersTurn(ulong clientId)
     {
         return clientId == _currentPlayerId;
@@ -211,8 +155,7 @@ public class BoardManager : NetSingleton<BoardManager>
 
     private IEnumerator SendTileCo(ulong playerId, int diceValue)
     {
-        Player player = _connectedClients[playerId];
-
+        var player = NetworkManager.Singleton.ConnectedClients[playerId].PlayerObject.GetComponent<Player>();
         int tileIndex = player.currentTile.tileIndex;
 
         for (int i = 0; i < diceValue; i++) //한 타일씩 -> 나중에 갈림길 고려
@@ -251,18 +194,6 @@ public class BoardManager : NetSingleton<BoardManager>
         }
 
         _currentPlayerId = _turnOrder[_currentPlayerIndex];
+        TogglePlayerDiceRpc(_currentPlayerId, true);
     }
-
-    // public void OnPlayersInput()
-    // {
-    //     if (_phaseMachine.IsPhase(_readyPhase))
-    //     {
-    //         ProcessDiceForTurnOrderButton(_localPlayerNumber);
-    //     }
-    //     else if (_phaseMachine.IsPhase(_playPhase) && IsPlayersTurn(_localPlayerNumber))
-    //     {
-    //         ProcessConfirmButton();
-    //     }
-    // }
-
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#74 


## 📝작업 내용

- 기존 방법
> 클라이언트가 접속하면 서버에서 동적으로 Player를 생성한 뒤 ClientId 와 Player를 Dictionary로 묶어서 관리
> 해당 Dictionary는 서버에만 정보가 존재하게 됨 -> 클라이언트에서 플레이어 정보 사용 불가한 이슈 
- 수정 방법
> `NetworkManager.Singleton.ConnectedClients[clientId].PlayerObject` 
> ConnectedClients 안에 PlayerObject 정보가 저장되어 있음 -> 이걸 받아와서 사용하도록 수정했습니다.

- 플레이어 프리팹에 NetworkAnimator 추가하여 애니메이션 동기화 처리했습니다.


## 💬리뷰 요구사항(선택)
RollDiceSequenceRpc(clientId, diceValue); 를 지우고 바로 주사위 turn, off 되는 함수 사용하는 걸로 수정했는데,
중간에 Sequence 함수가 있어야 할까요?
